### PR TITLE
Replace `jax.tree_multimap` with `jax.tree_util.tree_map`

### DIFF
--- a/perceiver_ar/experiment.py
+++ b/perceiver_ar/experiment.py
@@ -847,8 +847,8 @@ class Experiment(experiment.AbstractExperiment):
       grads, (loss_scalars, state) = grad_loss_fn(params, state,
                                                   microbatch_input,
                                                   grad_rng[loop_cnt])
-      grads_accum = jax.tree_multimap(jnp.add, grads_accum, grads)
-      loss_scalars_accum = jax.tree_multimap(jnp.add, loss_scalars_accum,
+      grads_accum = jax.tree_util.tree_map(jnp.add, grads_accum, grads)
+      loss_scalars_accum = jax.tree_util.tree_map(jnp.add, loss_scalars_accum,
                                              loss_scalars)
       return grads_accum, loss_scalars_accum, state
 
@@ -1016,7 +1016,7 @@ class Experiment(experiment.AbstractExperiment):
     batch_scalars = jax.tree_map(jnp.sum, batch_scalars)
 
     # Add to previous results.
-    return jax.tree_multimap(jnp.add, batch_scalars, scalars)
+    return jax.tree_util.tree_map(jnp.add, batch_scalars, scalars)
 
   def _sum_eval_scalars(self, scalars: Scalars):
     # Sum scalars across hosts.


### PR DESCRIPTION
`jax.tree_multimap` has been replaced by `jax.tree_util.tree_map` in the latest JAX library, as per [this issue](https://github.com/google/jax/pull/10126).  The change to have `tree_multimap` be an alias of `tree_map` was made in JAX v0.1.70 as per this [pull request](https://github.com/google/jax/pull/6585#event-4664344129), while the `requirements.txt` references v0.3.13, so this should not have any effects for those using the version of JAX in the requirements file, but fixes errors for those using more recent versions.