### PR TITLE
Fixes out-of-memory error

### DIFF
--- a/perceiver_ar/experiment.py
+++ b/perceiver_ar/experiment.py
@@ -42,6 +42,7 @@ import optax
 from perceiver_ar import perceiver_ar_model
 import tensorflow as tf
 
+# Ensure TensorFlow doesn't use entire GPU
 tf.config.set_visible_devices([], "GPU")
 
 FLAGS = flags.FLAGS

--- a/perceiver_ar/experiment.py
+++ b/perceiver_ar/experiment.py
@@ -42,7 +42,7 @@ import optax
 from perceiver_ar import perceiver_ar_model
 import tensorflow as tf
 
-# Ensure TensorFlow doesn't use entire GPU
+# Ensure TensorFlow doesn't use GPU.
 tf.config.set_visible_devices([], "GPU")
 
 FLAGS = flags.FLAGS

--- a/perceiver_ar/experiment.py
+++ b/perceiver_ar/experiment.py
@@ -42,6 +42,8 @@ import optax
 from perceiver_ar import perceiver_ar_model
 import tensorflow as tf
 
+tf.config.set_visible_devices([], "GPU")
+
 FLAGS = flags.FLAGS
 
 OptState = Tuple[optax.TraceState, optax.ScaleByScheduleState, optax.ScaleState]


### PR DESCRIPTION
This PR partially fixes #14.

As suggested by @cghawthorne, this fixes the out-of-memory error.  However, adding the `tf.config.set_visible_devices([], "GPU")` to the `inference.ipynb` notebook does not fix the error there.  So far the only thing that fixes that is adding `%env XLA_PYTHON_CLIENT_PREALLOCATE=false`.